### PR TITLE
Darstellung geändert

### DIFF
--- a/TextCrypt/Crypt.cs
+++ b/TextCrypt/Crypt.cs
@@ -44,17 +44,16 @@ namespace TextCrypt
             return encryptedText;
         }
 
-        public byte[] DecryptText(string input)
+        public string DecryptText(byte[] input)
         {
-            byte[] plainText = { };
-            using (MemoryStream ms = new MemoryStream(Encoding.Unicode.GetBytes(input)))
+            string plainText;
+            using (MemoryStream ms = new MemoryStream(input))
             {
                 using (CryptoStream cryptoStream = new CryptoStream(ms, aes.CreateDecryptor(keyBytes, ivBytes), CryptoStreamMode.Read))
                 {
                     using (StreamReader streamReader = new StreamReader(cryptoStream))
                     {
-                        string temp = streamReader.ReadToEnd();
-                        plainText = Encoding.Unicode.GetBytes(temp);
+                        plainText = streamReader.ReadToEnd();
                     }
                 }
             }

--- a/TextCrypt/Form1.cs
+++ b/TextCrypt/Form1.cs
@@ -17,7 +17,7 @@ namespace TextCrypt
             if (input != String.Empty)
             {
                 byte[] byteArray = crypt.EncryptText(input);
-                RtbOutput.Text = Encoding.Default.GetString(byteArray, 0, byteArray.Length);
+                RtbOutput.Text = Convert.ToBase64String(byteArray, 0, byteArray.Length);
             }
             else
             {
@@ -30,8 +30,7 @@ namespace TextCrypt
             string input = RtbInput.Text;
             if (input != String.Empty)
             {
-                byte[] byteArray = crypt.DecryptText(input);
-                RtbOutput.Text = Encoding.Default.GetString(byteArray, 0, byteArray.Length);
+                RtbOutput.Text = crypt.DecryptText(Convert.FromBase64String(input));
             }
             else
             { 


### PR DESCRIPTION
Darstellung in Base64 kodiert, damit es keine Probleme mit nicht darstellbaren Zeichen gibt.
Durch die Encryption werden Bytefolgen erzeugt, die nicht unbedingt darstellbare Zeichen sein müssen. Dadurch werden durch das rohe Anzeigen der Bytes einige Zeichen in der Ersatzdarstellung angezeigt, sodass der Inhalt verändert wird.
Durch das Kodieren mit Base64 wird garantiert, dass die Bytefolge mit dem ASCII Alphabet angezeigt werden kann.